### PR TITLE
fix: stop Telegram alerts for next-auth login errors

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,4 @@
 import type { NextAuthOptions } from "next-auth"
-import { notifyError } from "@/lib/notify"
 
 interface Profile {
   identificacao: string
@@ -19,33 +18,7 @@ interface Profile {
   email_preferencial: string
 }
 
-const NOISY_OAUTH_CALLBACK_PATTERNS = [
-  "state mismatch",
-  "state cookie was missing",
-  "state value could not be parsed",
-  "pkce code_verifier cookie was missing",
-  "pkce code_verifier value could not be parsed",
-  "nonce cookie was missing",
-  "nonce value could not be parsed",
-]
-
-function isNoisyAuthError(code: string, message: string): boolean {
-  if (code !== "OAUTH_CALLBACK_ERROR") return false
-  const m = message.toLowerCase()
-  return NOISY_OAUTH_CALLBACK_PATTERNS.some((p) => m.includes(p))
-}
-
 export const authOptions: NextAuthOptions = {
-  logger: {
-    error(code, metadata) {
-      const error = metadata instanceof Error ? metadata : metadata.error
-      if (isNoisyAuthError(code, error.message)) return
-      notifyError(`auth.ts / next-auth (${code})`, {
-        code,
-        message: error.message,
-      })
-    },
-  },
   session: {
     strategy: "jwt",
   },


### PR DESCRIPTION
## O que

Remove os alertas de login no Telegram que estavam gerando ruído (`OAUTH_CALLBACK_ERROR`, `CLIENT_FETCH_ERROR`, etc.).

## Como

- Remove o bloco `logger.error` custom do next-auth em `src/lib/auth.ts` — era a única origem desses alertas.
- Remove o filtro `NOISY_OAUTH_CALLBACK_PATTERNS` / `isNoisyAuthError`, agora morto.
- Remove o import não usado de `notifyError`.

Sem o logger custom, o next-auth volta a logar erros no console (sem Telegram). Os `notifyError` de fetch de dados (boletim, notas, dados do aluno, feedback) continuam intactos — não são ruído de login.